### PR TITLE
Simple empty search

### DIFF
--- a/repocribro/controllers/core.py
+++ b/repocribro/controllers/core.py
@@ -29,13 +29,10 @@ def search(query=''):
     ext_master = flask.current_app.container.get('ext_master')
 
     tabs = {}
-    active_tab = ''
-    if query != '':
-        ext_master.call('view_core_search_tabs',
-                        query=query, tabs_dict=tabs)
-        tabs = sorted(tabs.values())
-        active_tab = flask.request.args.get('tab', tabs[0].id)
-
+    ext_master.call('view_core_search_tabs',
+                    query=query, tabs_dict=tabs)
+    tabs = sorted(tabs.values())
+    active_tab = flask.request.args.get('tab', tabs[0].id)
     return flask.render_template(
         'core/search.html', query=query, tabs=tabs, active_tab=active_tab
     )

--- a/repocribro/ext_core.py
+++ b/repocribro/ext_core.py
@@ -229,15 +229,20 @@ class CoreExtension(Extension):
         :type tabs_dict: dict of str: ``repocribro.extending.helpers.ViewTab``
         """
         from .models import User, Organization, Repository
-        users = User.fulltext_query(
-            query, self.db.session.query(User)
-        ).all()
-        orgs = Organization.fulltext_query(
-            query, self.db.session.query(Organization)
-        ).all()
-        repos = Repository.fulltext_query(
-            query, self.db.session.query(Repository)
-        ).all()
+        if query == '':
+            users = self.db.session.query(User).all()
+            orgs = self.db.session.query(Organization).all()
+            repos = self.db.session.query(Repository).all()
+        else:
+            users = User.fulltext_query(
+                query, self.db.session.query(User)
+            ).all()
+            orgs = Organization.fulltext_query(
+                query, self.db.session.query(Organization)
+            ).all()
+            repos = Repository.fulltext_query(
+                query, self.db.session.query(Repository)
+            ).all()
 
         tabs_dict['repositories'] = ViewTab(
             'repositories', 'Repositories', 0,

--- a/repocribro/templates/core/search.html
+++ b/repocribro/templates/core/search.html
@@ -28,6 +28,10 @@
     </div>
     {% else %}
         <div class="alert alert-info">Use search field for exploring what are you interested in!</div>
+
+        <div class="search-results">
+            {{ tabzone(tabs, active_tab) }}
+        </div>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Implemented requested improvements from issue #11 

Now is possible to see all entities on empty-query search page, it leads to next improving of searching mechanism #15